### PR TITLE
Removing go tip Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: go
 go:
   - 1.7.1
-  - tip
 before_install:
   - go get github.com/mattn/goveralls
 script:


### PR DESCRIPTION
It's not really necessary right now and is just slowing down each build.
