### PR TITLE
Refactoring Notes API to take a struct instead of individual params

### DIFF
--- a/prosper/notes.go
+++ b/prosper/notes.go
@@ -1,6 +1,9 @@
 package prosper
 
-import "github.com/mtlynch/gofn-prosper/types"
+import (
+	"github.com/mtlynch/gofn-prosper/prosper/thin"
+	"github.com/mtlynch/gofn-prosper/types"
+)
 
 // NoteFetcher supports the Notes API for retrieving the user's notes.
 type NoteFetcher interface {
@@ -11,7 +14,10 @@ type NoteFetcher interface {
 // implements the REST API described at:
 // https://developers.prosper.com/docs/investor/notes-api/
 func (c Client) Notes(offset, limit int) (types.NotesResponse, error) {
-	notesResponseRaw, err := c.rawClient.Notes(offset, limit)
+	notesResponseRaw, err := c.rawClient.Notes(thin.NotesParams{
+		Offset: offset,
+		Limit:  limit,
+	})
 	if err != nil {
 		return types.NotesResponse{}, err
 	}

--- a/prosper/notes_test.go
+++ b/prosper/notes_test.go
@@ -19,9 +19,9 @@ var (
 	errMockParserFail     = errors.New("mock parser error")
 )
 
-func (c *mockRawClient) Notes(offset, limit int) (thin.NotesResponse, error) {
-	gotOffset = offset
-	gotLimit = limit
+func (c *mockRawClient) Notes(p thin.NotesParams) (thin.NotesResponse, error) {
+	gotOffset = p.Offset
+	gotLimit = p.Limit
 	return c.notesResponse, c.err
 }
 

--- a/prosper/thin/client.go
+++ b/prosper/thin/client.go
@@ -77,7 +77,7 @@ func (c Client) DoRequest(method, urlStr string, body io.Reader, response interf
 // RawAPIHandler is a thin implementation of the Prosper REST APIs.
 type RawAPIHandler interface {
 	Accounts() (AccountsResponse, error)
-	Notes(offset, limit int) (NotesResponse, error)
+	Notes(NotesParams) (NotesResponse, error)
 	Search(SearchParams) (SearchResponse, error)
 	PlaceBid([]BidRequest) (OrderResponse, error)
 	OrderStatus(string) (OrderResponse, error)

--- a/prosper/thin/notes.go
+++ b/prosper/thin/notes.go
@@ -1,8 +1,18 @@
 package thin
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type (
+	// NotesParams contains the parameters to the Notes API.
+	NotesParams struct {
+		Offset int
+		Limit  int
+		// TODO(mtlynch): Implement support for the sort_by parameter.
+	}
+
 	// NoteResult contains response information about a single Propser note in
 	// minimally parsed form.
 	NoteResult struct {
@@ -48,11 +58,23 @@ type (
 // Notes returns a subset of the notes that the user owns. Notes partially
 // implements the REST API described at:
 // https://developers.prosper.com/docs/investor/notes-api/
-func (c Client) Notes(offset, limit int) (response NotesResponse, err error) {
-	url := fmt.Sprintf("%s/notes/?offset=%d&limit=%d", c.baseURL, offset, limit)
+func (c Client) Notes(p NotesParams) (response NotesResponse, err error) {
+	q := notesParamsToQueryString(p)
+	url := fmt.Sprintf("%s/notes/?%s", c.baseURL, q)
 	err = c.DoRequest("GET", url, nil, &response)
 	if err != nil {
 		return NotesResponse{}, err
 	}
 	return response, nil
+}
+
+func notesParamsToQueryString(p NotesParams) string {
+	var clauses []string
+	if p.Offset != 0 {
+		clauses = append(clauses, fmt.Sprintf("offset=%d", p.Offset))
+	}
+	if p.Limit != 0 {
+		clauses = append(clauses, fmt.Sprintf("limit=%d", p.Limit))
+	}
+	return strings.Join(clauses, "&")
 }

--- a/prosper/thin/notes_test.go
+++ b/prosper/thin/notes_test.go
@@ -15,8 +15,7 @@ func TestNotesSuccessfulResponse(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, "GET")
 			testFormValues(t, r, values{
-				"offset": "0",
-				"limit":  "25",
+				"limit": "25",
 			})
 			fmt.Fprint(w, `{
    "result": [
@@ -89,7 +88,10 @@ func TestNotesSuccessfulResponse(t *testing.T) {
 		baseURL:      server.URL,
 		tokenManager: mockTokenManager{},
 	}
-	got, err := client.Notes(0, 25)
+	got, err := client.Notes(NotesParams{
+		Offset: 0,
+		Limit:  25,
+	})
 	if err != nil {
 		t.Fatalf("client.Notes failed: %v", err)
 	}
@@ -179,8 +181,48 @@ func TestNotesErrorResponse(t *testing.T) {
 		baseURL:      server.URL,
 		tokenManager: mockTokenManager{},
 	}
-	_, err := client.Notes(0, 25)
+	_, err := client.Notes(NotesParams{
+		Offset: 0,
+		Limit:  25,
+	})
 	if err == nil {
 		t.Fatal("client.Notes should fail when server returns error")
+	}
+}
+
+func TestNotesParamsToQueryString(t *testing.T) {
+	var tests = []struct {
+		p    NotesParams
+		want string
+	}{
+		{
+			p:    NotesParams{},
+			want: "",
+		},
+		{
+			p: NotesParams{
+				Offset: 25,
+			},
+			want: "offset=25",
+		},
+		{
+			p: NotesParams{
+				Limit: 46,
+			},
+			want: "limit=46",
+		},
+		{
+			p: NotesParams{
+				Offset: 55,
+				Limit:  7,
+			},
+			want: "offset=55&limit=7",
+		},
+	}
+	for _, tt := range tests {
+		got := notesParamsToQueryString(tt.p)
+		if got != tt.want {
+			t.Errorf("notesParamsToQueryString() got: %v, want: %v", got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
This should make the API more flexible if the parameters change in the future.
